### PR TITLE
Skip deploy ci on renovate PR

### DIFF
--- a/.github/workflows/build_and_deploy.yml
+++ b/.github/workflows/build_and_deploy.yml
@@ -6,7 +6,7 @@ jobs:
   hook:
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.actor != 'dependabot[bot]' && !contains(github.repository, "template")
+    if: ! startsWith(github.ref_name,'renovate/') && !contains(github.repository, "template")
     steps:
       - name: Repository Dispatch
         uses: peter-evans/repository-dispatch@v1


### PR DESCRIPTION
## What?
Skip deploy ci on renovate PR

## Why?
renovate の自動マージされるPRはデプロイする必要がないから